### PR TITLE
fixed bug camera orientation closes #42

### DIFF
--- a/app/src/main/java/com/digitalvotingpass/digitalvotingpass/Camera2BasicFragment.java
+++ b/app/src/main/java/com/digitalvotingpass/digitalvotingpass/Camera2BasicFragment.java
@@ -50,6 +50,7 @@ import android.util.Log;
 import android.util.Size;
 import android.util.SparseIntArray;
 import android.view.LayoutInflater;
+import android.view.OrientationEventListener;
 import android.view.Surface;
 import android.view.TextureView;
 import android.view.View;
@@ -92,6 +93,9 @@ public class Camera2BasicFragment extends Fragment
         ORIENTATIONS.append(Surface.ROTATION_270, 180);
     }
 
+    // listener for detecting orientation changes
+    private OrientationEventListener orientationListener = null;
+
     /**
      * Tag for the {@link Log}.
      */
@@ -116,6 +120,7 @@ public class Camera2BasicFragment extends Fragment
 
         @Override
         public void onSurfaceTextureAvailable(SurfaceTexture texture, int width, int height) {
+            orientationListener.enable();
             openCamera(width, height);
         }
 
@@ -126,6 +131,7 @@ public class Camera2BasicFragment extends Fragment
 
         @Override
         public boolean onSurfaceTextureDestroyed(SurfaceTexture texture) {
+            orientationListener.disable();
             return true;
         }
 
@@ -321,6 +327,11 @@ public class Camera2BasicFragment extends Fragment
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        orientationListener = new OrientationEventListener(this.getActivity()) {
+            public void onOrientationChanged(int orientation) {
+                configureTransform(mTextureView.getWidth(), mTextureView.getHeight());
+            }
+        };
         int threadsToStart = Runtime.getRuntime().availableProcessors() / 2;
         if (ocrThreadNumberOverride > 0) {
             threadsToStart = ocrThreadNumberOverride;
@@ -675,6 +686,7 @@ public class Camera2BasicFragment extends Fragment
         RectF bufferRect = new RectF(0, 0, mPreviewSize.getHeight(), mPreviewSize.getWidth());
         float centerX = viewRect.centerX();
         float centerY = viewRect.centerY();
+        Log.e(TAG, "Rotation: " + rotation);
         if (Surface.ROTATION_90 == rotation || Surface.ROTATION_270 == rotation) {
             bufferRect.offset(centerX - bufferRect.centerX(), centerY - bufferRect.centerY());
             matrix.setRectToRect(viewRect, bufferRect, Matrix.ScaleToFit.FILL);

--- a/app/src/main/java/com/digitalvotingpass/digitalvotingpass/TesseractOCR.java
+++ b/app/src/main/java/com/digitalvotingpass/digitalvotingpass/TesseractOCR.java
@@ -210,6 +210,9 @@ public class TesseractOCR {
             if (times.get(i) > max) max = times.get(i);
             curravg += times.get(i);
         }
-        Log.e(TAG, "Max runtime was " + max/1000f + " sec and avg was " + curravg/times.size()/1000f + " tot tries: " + times.size());
+        // prevent divide by zero
+        if(times.size()>0) {
+            Log.e(TAG, "Max runtime was " + max / 1000f + " sec and avg was " + curravg / times.size() / 1000f + " tot tries: " + times.size());
+        }
     }
 }

--- a/app/src/main/res/layout-land/fragment_camera2_basic.xml
+++ b/app/src/main/res/layout-land/fragment_camera2_basic.xml
@@ -15,7 +15,6 @@
 -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_height="match_parent">
 
     <com.digitalvotingpass.digitalvotingpass.AutoFitTextureView


### PR DESCRIPTION
Added a orientationlistener that calls an already in place function that adjusts the camera preview. Screen rotation is a bit slower though...

Please check if the MRZ are still scanned correctly even in the case where the camera preview used to be upside down, I don't have a proper ID with readable MRZ here.