### PR TITLE
44_fix black bar issue

### DIFF
--- a/app/src/main/java/com/digitalvotingpass/camera/AutoFitTextureView.java
+++ b/app/src/main/java/com/digitalvotingpass/camera/AutoFitTextureView.java
@@ -57,20 +57,29 @@ public class AutoFitTextureView extends TextureView {
         requestLayout();
     }
 
+    /**
+     * Crops the camera output to the same aspect ratio as the screen.
+     * @param widthMeasureSpec
+     * @param heightMeasureSpec
+     */
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+
         int width = MeasureSpec.getSize(widthMeasureSpec);
         int height = MeasureSpec.getSize(heightMeasureSpec);
         if (0 == mRatioWidth || 0 == mRatioHeight) {
             setMeasuredDimension(width, height);
-        } else {
-            if (width < height * mRatioWidth / mRatioHeight) {
-                setMeasuredDimension(width, width * mRatioHeight / mRatioWidth);
-            } else {
-                setMeasuredDimension(height * mRatioWidth / mRatioHeight, height);
+        }
+        else {
+            if (width > height*mRatioWidth/mRatioHeight) {
+                setMeasuredDimension(width, width*mRatioHeight/mRatioWidth);
+            }
+            else {
+                setMeasuredDimension(height*mRatioWidth/mRatioHeight, height);
             }
         }
+
     }
 
 }

--- a/app/src/main/java/com/digitalvotingpass/camera/Camera2BasicFragment.java
+++ b/app/src/main/java/com/digitalvotingpass/camera/Camera2BasicFragment.java
@@ -603,7 +603,6 @@ public class Camera2BasicFragment extends Fragment
                     mTextureView.setAspectRatio(
                             mPreviewSize.getWidth(), mPreviewSize.getHeight());
                 } else {
-                    //TODO find out why and how this +150 removes the black vertical bar
                     mTextureView.setAspectRatio(
                             mPreviewSize.getHeight(), mPreviewSize.getWidth());
                 }


### PR DESCRIPTION
Fixes the aspect ratio of the camerapreview so there is no black bar displayed anymore. Please test on multiple devices to be sure that the fix actually works.